### PR TITLE
Added whitelist to dragonsreach trellis for mod compat.

### DIFF
--- a/LightPlacer/CS Light/CS Light -  Interior Windows Dragonsreach.json
+++ b/LightPlacer/CS Light/CS Light -  Interior Windows Dragonsreach.json
@@ -2,6 +2,7 @@
   {
     "lights": [
       {
+      "whiteList": ["0x08786a", "0x08785f", "0x0dcafd", "0x0D7D38"],
         "data": {
           "fade": 1.5,
           "externalEmittance": "FXLightRegionSunlight",


### PR DESCRIPTION
Some interior overhauls abuse that mesh which means new lights are placed in spots where they shouldn't