### PR TITLE
fix: Overlapping/Conflicting placed light sources

### DIFF
--- a/LightPlacer/CS Light/CS Light - Blackreach.json
+++ b/LightPlacer/CS Light/CS Light - Blackreach.json
@@ -213,21 +213,6 @@
     ]
   },
   {
-    "models": ["clutter\\blackreach\\blackreachvinefloor01.nif"],
-    "lights": [
-      {
-        "points": [[0.0, 0.0, 0.0]],
-        "data": {
-          "light": "MagicLightWhite01",
-          "color": [0.212, 1.0, 0.714],
-          "radius": 200.0,
-          "fade": 0.5,
-          "flags": "Simple|PortalStrict|Linear"
-        }
-      }
-    ]
-  },
-  {
     "lights": [
       {
         "data": {

--- a/LightPlacer/CS Light/CS Light - Bound Weapons.json
+++ b/LightPlacer/CS Light/CS Light - Bound Weapons.json
@@ -5,36 +5,6 @@
         "data": {
           "flags": "PortalStrict|Linear",
           "color": [127, 102, 204],
-          "fade": 2.0,
-          "light": "MagicLightShockHand",
-          "radius": 71
-        },
-        "points": [[0.0, 0.0, 0.0]]
-      }
-    ],
-    "models": ["weapons\\boundweapons\\boundarrowflight.nif"]
-  },
-  {
-    "lights": [
-      {
-        "data": {
-          "flags": "PortalStrict|Linear",
-          "color": [97, 11, 247],
-          "fade": 1.0,
-          "light": "MagicLightShockHand",
-          "radius": 125
-        },
-        "points": [[0.0, 4.92, 0.0]]
-      }
-    ],
-    "models": ["dlc01\\effects\\fxdlc1sctreasurebarrier01.nif"]
-  },
-  {
-    "lights": [
-      {
-        "data": {
-          "flags": "PortalStrict|Linear",
-          "color": [127, 102, 204],
           "fade": 1.0,
           "light": "MagicLightShockHand",
           "radius": 71
@@ -43,21 +13,6 @@
       }
     ],
     "models": ["dlc02\\weapons\\bounddaggerencheffects.nif"]
-  },
-  {
-    "lights": [
-      {
-        "data": {
-          "flags": "PortalStrict|Linear",
-          "color": [127, 102, 204],
-          "fade": 1.0,
-          "light": "MagicLightShockHand",
-          "radius": 71
-        },
-        "points": [[-0.0, -25.0, -0.0]]
-      }
-    ],
-    "models": ["weapons\\boundweapons\\boundarrow.nif"]
   },
   {
     "lights": [

--- a/LightPlacer/CS Light/CS Light - College.json
+++ b/LightPlacer/CS Light/CS Light - College.json
@@ -38,19 +38,5 @@
         }
       }
     ]
-  },
-  {
-    "models": ["Magic\\LightSpellStaticLight.nif"],
-    "lights": [
-      {
-        "points": [[0.0, 0.0, 0.0]],
-        "data": {
-          "flags": "PortalStrict|Linear",
-          "light": "MagicLightWhite01",
-          "radius": 128.0,
-          "fade": 1.0
-        }
-      }
-    ]
   }
 ]

--- a/LightPlacer/CS Light/CS Light - Furniture ISL.json
+++ b/LightPlacer/CS Light/CS Light - Furniture ISL.json
@@ -305,8 +305,7 @@
       "furniture\\alchemyworkstation_1.nif",
       "furniture\\alchemyworkstation_2.nif",
       "furniture\\alchemyworkstation_3.nif",
-      "furniture\\workbenches\\alchemyworkstation01.nif",
-      "furniture\\alchemyworkstation.nif"
+      "furniture\\workbenches\\alchemyworkstation01.nif"
     ],
     "lights": [
       {

--- a/LightPlacer/CS Light/CS Light - Misc Effects.json
+++ b/LightPlacer/CS Light/CS Light - Misc Effects.json
@@ -85,46 +85,6 @@
     "lights": [
       {
         "data": {
-          "color": [54, 101, 255],
-          "fade": 1.0,
-          "light": "MagicLightWhite01",
-          "radius": 19,
-          "flags": "Linear"
-        },
-        "points": [[0.24, 0.41, -0.02]]
-      }
-    ],
-    "models": ["magic\\lightspellstaticlight.nif"]
-  },
-  {
-    "lights": [
-      {
-        "data": {
-          "color": [189, 143, 91],
-          "fade": 1.0,
-          "light": "MagicLightWhite01",
-          "radius": 98,
-          "flags": "Linear"
-        },
-        "points": [[-0.13, -2.55, 1.97]]
-      },
-      {
-        "data": {
-          "color": [82, 184, 255],
-          "fade": 1.0,
-          "light": "MagicLightWhite01",
-          "radius": 75,
-          "flags": "Linear"
-        },
-        "points": [[0.0, 0.0, 15.0]]
-      }
-    ],
-    "models": ["dlc01\\effects\\dlc1falmervalleybrazierlight.nif"]
-  },
-  {
-    "lights": [
-      {
-        "data": {
           "color": [85, 85, 85],
           "fade": 2.8,
           "light": "MagicLightWhite01",
@@ -244,21 +204,6 @@
     "lights": [
       {
         "data": {
-          "color": [23, 77, 255],
-          "fade": 1.0,
-          "light": "MagicLightWhite01",
-          "radius": 22,
-          "flags": "Linear"
-        },
-        "points": [[0.0, 0.0, 0.0]]
-      }
-    ],
-    "models": ["magic\\lightspellhazard.nif"]
-  },
-  {
-    "lights": [
-      {
-        "data": {
           "color": [244, 244, 128],
           "fade": 2.0,
           "light": "MagicLightWhite01",
@@ -314,36 +259,6 @@
       }
     ],
     "models": ["effects\\mgmagicfirepillarsmall.nif"]
-  },
-  {
-    "lights": [
-      {
-        "data": {
-          "color": [21, 76, 255],
-          "fade": 1.0,
-          "light": "MagicLightWhite01",
-          "radius": 15,
-          "flags": "Linear"
-        },
-        "points": [[-3.37, 40.18, 20.25]]
-      }
-    ],
-    "models": ["magic\\lightspellactorfx.nif"]
-  },
-  {
-    "lights": [
-      {
-        "data": {
-          "color": [26, 77, 255],
-          "fade": 2.0,
-          "light": "MagicLightWhite01",
-          "radius": 284,
-          "flags": "Linear"
-        },
-        "points": [[0.0, 0.0, -37.26]]
-      }
-    ],
-    "models": ["effects\\mgmagicfirepillar01.nif"]
   },
   {
     "lights": [


### PR DESCRIPTION
These conflicts were found using the mod [Light Conflict Resolver](https://www.nexusmods.com/skyrimspecialedition/mods/175086?tab=posts). It also helped me find overlapping light sources from other mods in my modlist that provided LightPlacer config json files. So far, would recommend using it.

<img width="2560" height="1600" alt="Screenshot (97)" src="https://github.com/user-attachments/assets/6f7c40db-e995-4673-b399-50374ed22936" />


These are the following conflicts that were found.

# Conflict 1

Mesh in conflict is `blackreachvinefloor01.nif`

### Blackreach.json

```json
{
    "lights": [
      {
        "data": {
          "color": [51, 255, 178],
          "fade": 0.75,
          "light": "MagicLightWhite01",
          "radius": 71,
          "flags": "PortalStrict|Linear"
        },
        "points": [[0.0, 0.0, 20.0]]
      }
    ],
    "models": ["clutter\\blackreach\\blackreachvinefloor01.nif"]
  },
  {
    "models": ["clutter\\blackreach\\blackreachvinefloor01.nif"],
    "lights": [
      {
        "points": [[0.0, 0.0, 0.0]],
        "data": {
          "light": "MagicLightWhite01",
          "color": [0.212, 1.0, 0.714],
          "radius": 200.0,
          "fade": 0.5,
          "flags": "Simple|PortalStrict|Linear"
        }
      }
    ]
  },
```


# Conflict 2

Meshes in conflict are `boundarrowfilght.nif`, `fxdlc1sctreasurebarrier01` and `boundarrow.nif`

### Bound Weapons.json

```json
{
    "lights": [
      {
        "data": {
          "color": [127, 102, 204],
          "fade": 2.0,
          "light": "MagicLightWhite01",
          "radius": 71,
          "flags": "Linear"
        },
        "points": [[-0.0, -15.0, 0.0]]
      }
    ],
    "models": ["weapons\\boundweapons\\boundarrowflight.nif"]
},
{
    "lights": [
      {
        "data": {
          "color": [97, 11, 247],
          "fade": 1.0,
          "light": "MagicLightWhite01",
          "radius": 355,
          "flags": "Linear"
        },
        "points": [[0.0, 4.92, 0.0]]
      }
    ],
    "models": ["dlc01\\effects\\fxdlc1sctreasurebarrier01.nif"]
},
{
    "lights": [
      {
        "data": {
          "color": [127, 102, 204],
          "fade": 2.0,
          "light": "MagicLightWhite01",
          "radius": 71,
          "flags": "Linear"
        },
        "points": [[-0.0, -25.0, -0.0]]
      }
    ],
    "models": ["weapons\\boundweapons\\boundarrow.nif"]
}
```

### Misc Effects.json

```json
{
    "lights": [
      {
        "data": {
          "flags": "PortalStrict|Linear",
          "color": [127, 102, 204],
          "fade": 2.0,
          "light": "MagicLightShockHand",
          "radius": 71
        },
        "points": [[0.0, 0.0, 0.0]]
      }
    ],
    "models": ["weapons\\boundweapons\\boundarrowflight.nif"]
  },
  {
    "lights": [
      {
        "data": {
          "flags": "PortalStrict|Linear",
          "color": [97, 11, 247],
          "fade": 1.0,
          "light": "MagicLightShockHand",
          "radius": 125
        },
        "points": [[0.0, 4.92, 0.0]]
      }
    ],
    "models": ["dlc01\\effects\\fxdlc1sctreasurebarrier01.nif"]
  },
  {
    "lights": [
      {
        "data": {
          "flags": "PortalStrict|Linear",
          "color": [127, 102, 204],
          "fade": 1.0,
          "light": "MagicLightShockHand",
          "radius": 71
        },
        "points": [[-0.0, -25.0, -0.0]]
      }
    ],
    "models": ["weapons\\boundweapons\\boundarrow.nif"]
  },
```

# Conflict 3

Meshes in conflict  are `lightspellactorfx.nif` and `lightspellhazard.nif`

### Magic FX.json

```json
{
    "lights": [
      {
        "data": {
          "flags": "InverseSquare|IgnoreScale|Linear",
          "color": [9, 136, 234],
          "fade": 0.4,
          "light": "MagicLightWhite01",
          "size": 2.0
        },
        "points": [[-3.37, 40.18, 20.25]]
      }
    ],
    "models": ["magic\\lightspellactorfx.nif"]
},
{
    "lights": [
      {
        "data": {
          "flags": "InverseSquare|IgnoreScale|Linear",
          "color": [9, 136, 234],
          "fade": 0.4,
          "light": "MagicLightWhite01",
          "size": 2.0
        },
        "points": [[0.0, 0.0, 0.0]]
      }
    ],
    "models": ["magic\\lightspellhazard.nif"]
},
```

### Misc Effects.json

```json
{
    "lights": [
      {
        "data": {
          "color": [21, 76, 255],
          "fade": 1.0,
          "light": "MagicLightWhite01",
          "radius": 15,
          "flags": "Linear"
        },
        "points": [[-3.37, 40.18, 20.25]]
      }
    ],
    "models": ["magic\\lightspellactorfx.nif"]
},
{
    "lights": [
      {
        "data": {
          "color": [23, 77, 255],
          "fade": 1.0,
          "light": "MagicLightWhite01",
          "radius": 22,
          "flags": "Linear"
        },
        "points": [[0.0, 0.0, 0.0]]
      }
    ],
    "models": ["magic\\lightspellhazard.nif"]
},
```

# Conflict 4

Mesh in conflict is `furniture\\alchemyworkstation.nif` with three lights

### Furniture ISL.json

```json
{
    "models": [
      "furniture\\alchemyworkbench.nif",
      "furniture\\alchemyworkstation.nif",
      "furniture\\workbenches\\alchemyworkbench01.nif"
    ],
    "lights": [
      {
        "nodes": ["Burner01"],
        "data": {
          "color": [139, 71, 11],
          "light": "MagicLightWhite01",
          "cutoff": 0.1,
          "fade": 0.2,
          "flags": "IgnoreScale|InverseSquare|PortalStrict|Linear"
        }
      }
    ]
},
{
    "models": ["furniture\\alchemyworkstation.nif"],
    "lights": [
      {
        "points": [[0.0, 50.0, 74.0]],
        "data": {
          "color": [15, 97, 13],
          "light": "MagicLightWhite01",
          "cutoff": 0.2,
          "fade": 0.275,
          "size": 2.0,
          "flags": "IgnoreScale|InverseSquare|PortalStrict|Linear"
        }
      }
    ]
},
{
    "models": [
      "furniture\\alchemyworkbench_1.nif",
      "furniture\\alchemyworkbench_2.nif",
      "furniture\\alchemyworkbench_3.nif",
      "furniture\\alchemyworkstation_1.nif",
      "furniture\\alchemyworkstation_2.nif",
      "furniture\\alchemyworkstation_3.nif",
      "furniture\\workbenches\\alchemyworkstation01.nif",
      "furniture\\alchemyworkstation.nif"
    ],
    "lights": [
      {
        "nodes": ["Burner01"],
        "data": {
          "color": [139, 71, 11],
          "light": "MagicLightWhite01",
          "cutoff": 0.2,
          "fade": 0.4,
          "size": 2.0,
          "flags": "IgnoreScale|InverseSquare|PortalStrict|Linear"
        }
      }
    ]
  }
```

# Conflict 5

Mesh in conflict is `dlc1falmervalleybrazierlight.nif`

### Falmer.json

```json
{
    "lights": [
      {
        "data": {
          "flags": "PortalStrict|Linear",
          "color": [189, 143, 91],
          "fade": 1.0,
          "light": "MagicLightShockHand",
          "radius": 98
        },
        "points": [[-0.13, -2.55, 1.97]]
      },
      {
        "data": {
          "flags": "PortalStrict|Linear",
          "color": [82, 184, 255],
          "fade": 1.0,
          "light": "MagicLightShockHand",
          "radius": 284
        },
        "points": [[0.0, 0.0, 15.0]]
      }
    ],
    "models": ["dlc01\\effects\\dlc1falmervalleybrazierlight.nif"]
  }
```

### Misc Effects.json

```json
{
    "lights": [
      {
        "data": {
          "color": [189, 143, 91],
          "fade": 1.0,
          "light": "MagicLightWhite01",
          "radius": 98,
          "flags": "Linear"
        },
        "points": [[-0.13, -2.55, 1.97]]
      },
      {
        "data": {
          "color": [82, 184, 255],
          "fade": 1.0,
          "light": "MagicLightWhite01",
          "radius": 75,
          "flags": "Linear"
        },
        "points": [[0.0, 0.0, 15.0]]
      }
    ],
    "models": ["dlc01\\effects\\dlc1falmervalleybrazierlight.nif"]
  }
```

# Conflict 6

Mesh in conflict is `meshes/magic/lightspellstaticlight.nif`

### College.json

```json
{
    "models": ["Magic\\LightSpellStaticLight.nif"],
    "lights": [
      {
        "points": [[0.0, 0.0, 0.0]],
        "data": {
          "flags": "PortalStrict|Linear",
          "light": "MagicLightWhite01",
          "radius": 128.0,
          "fade": 1.0
        }
      }
    ]
  }
```

### Magic FX.json

```json
{
    "lights": [
      {
        "data": {
          "flags": "InverseSquare|IgnoreScale|Linear",
          "color": [54, 101, 255],
          "fade": 0.4,
          "light": "MagicLightWhite01",
          "size": 2.0
        },
        "points": [[0.24, 0.41, -0.02]]
      }
    ],
    "models": ["magic\\lightspellstaticlight.nif"]
  },
```

### Misc Effects.json

```json
{
    "lights": [
      {
        "data": {
          "color": [54, 101, 255],
          "fade": 1.0,
          "light": "MagicLightWhite01",
          "radius": 19,
          "flags": "Linear"
        },
        "points": [[0.24, 0.41, -0.02]]
      }
    ],
    "models": ["magic\\lightspellstaticlight.nif"]
  },
```

# Conflict 7

Mesh in conflict is `meshes/effects/mgmagicfirepillar01.nif`

### College.json

```json
{
    "models": [
      "effects\\mgaugurfx01.nif",
      "effects\\mgmagicfirepillar01.nif",
      "effects\\mgmagicfirepillareye01.nif",
      "effects\\mgmagicfirepillarmidden01.nif",
      "effects\\mgmagicfirepillarsmall.nif"
    ],
    "lights": [
      {
        "nodes": [
          "MeshInnerCore",
          "FXfireWithEmbers01",
          "FXfireWithEmbers02",
          "lightrays01",
          "AttachLight01"
        ],
        "data": {
          "flags": "PortalStrict|Linear",
          "light": "MGFirePillarLightBlue",
          "radius": 350.0,
          "fade": 2.0
        }
      }
    ]
  },
  {
    "models": ["effects\\MGMagicFirePillar01.nif"],
    "lights": [
      {
        "points": [[0.0, 0.0, 0.0]],
        "data": {
          "flags": "PortalStrict|Linear",
          "light": "MGFirePillarLightBlue",
          "radius": 128.0,
          "fade": 1.0
        }
      }
    ]
  }
```

### Misc Effects.json

```json
{
    "lights": [
      {
        "data": {
          "color": [26, 77, 255],
          "fade": 2.0,
          "light": "MagicLightWhite01",
          "radius": 284,
          "flags": "Linear"
        },
        "points": [[0.0, 0.0, -37.26]]
      }
    ],
    "models": ["effects\\mgmagicfirepillar01.nif"]
  },
```